### PR TITLE
:on_return option -- retry based on the result of the block

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Here are the available options:
 `Timeout::Error`, array of exceptions to rescue for each attempt, or
 and array of exception & regex pairs.
 
+`on_return` (default: nil) - Allows the return value of the code block
+to be examined and retried if the Proc returns true
+
 `on_retry` - (default: nil) - Proc to call after each attempt is rescued
 
 You can pass options via an options `Hash`. This example will only retry on a `Timeout::Error`, retry 3 times and sleep for a full second before each attempt.
@@ -107,6 +110,26 @@ retriable :interval => (200/1000.0), :timeout => (500/1000.0) do
   # code here...
 end
 ```
+
+You can retry based on the return value of the code block:
+
+```ruby
+retriable :on_return => Proc.new { |return_value, attempt_count| return_value != OK } do
+  # code here...
+end
+```
+
+The Proc provided to the :on_return option should return true if the code block should be executed again. If all retry attempts have been exhausted, the last return value of the block is returned in the case there was no exception thrown.
+
+```ruby
+return_values = [1,2,3]
+result = retriable :tries => 3, :on_return => Proc.new { |return_value, attempt_count| return_value < 10 } do
+  return_values.shift
+end
+
+result==3 # true  
+```
+
 
 Retriable also provides a callback called `:on_retry` that will run after an exception is rescued. This callback provides the number of `tries`, and the `exception` that was raised in the current attempt. As these are specified in a `Proc`, unnecessary variables can be left out of the parameter list.
 
@@ -162,4 +185,4 @@ end
 Credits
 -------
 
-Retriable was originally forked from the retryable-rb gem by [Robert Sosinski](https://github.com/robertsosinski), which in turn originally inspired by code written by [Michael Celona](http://github.com/mcelona) and later assisted by [David Malin](http://github.com/dmalin). The [attempt](https://rubygems.org/gems/attempt) gem by Daniel J. Berger was also an inspiration.
+Retriable was originally forked from the retryable-rb gem by [Robert Sosinski](https://github.com/robertsosinski), which in turn originally inspired by code written by [Michael Celona](http://github.com/mcelona) and later assisted by [David Malin](http://github.com/dmalin). The [attempt](https://rubygems.org/gems/attempt) gem by Daniel J. Berger was also an inspiration. [Lamont Nelson] (http://github.com/lamontnelson) contributed the code for retrying based on the return value of the code block.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ retriable :interval => (200/1000.0), :timeout => (500/1000.0) do
 end
 ```
 
+You can pass a proc for the sleep interval:
+
+```ruby
+retriable :interval => Proc.new { |attempt| (2**attempt-1)/2 } do
+  # code here...
+end # backoff exponentially
+```
+
 You can retry based on the return value of the code block:
 
 ```ruby

--- a/lib/retriable/retriable.rb
+++ b/lib/retriable/retriable.rb
@@ -25,6 +25,15 @@ module Retriable
 
       yield self if block_given?
     end
+    
+    def perform_sleep(retry_count)
+      if @interval.kind_of?(Proc)
+        sleep_interval = @interval.call(retry_count) 
+      else
+        sleep_interval = @interval
+      end
+      sleep(sleep_interval) if sleep_interval > 0
+    end
 
     def perform
       count = 0
@@ -42,7 +51,7 @@ module Retriable
           @tries -= 1
           if @tries > 0
             count += 1
-            sleep @interval if @interval > 0
+            perform_sleep(count)
             @on_retry.call(exception, count) if @on_retry
             retry
           else

--- a/lib/retriable/retriable.rb
+++ b/lib/retriable/retriable.rb
@@ -4,6 +4,8 @@ require 'timeout'
 
 module Retriable
   extend self
+  
+  class InvalidReturn < StandardError; end;
 
   class Retry
     attr_accessor :tries
@@ -11,6 +13,7 @@ module Retriable
     attr_accessor :timeout
     attr_accessor :on
     attr_accessor :on_retry
+    attr_accessor :on_return
 
     def initialize
       @tries      = 3
@@ -18,18 +21,22 @@ module Retriable
       @timeout    = nil
       @on         = [StandardError, Timeout::Error]
       @on_retry   = nil
+      @on_return  = nil
 
       yield self if block_given?
     end
 
     def perform
       count = 0
+      result = nil
       begin
         if @timeout
-          Timeout::timeout(@timeout) { yield }
+          Timeout::timeout(@timeout) { result = yield }
         else
-          yield
+          result = yield
         end
+        raise InvalidReturn if @on_return && @on_return.call(result, count+1)
+        result
       rescue Exception => exception
         if matches_exception_spec? exception
           @tries -= 1
@@ -39,7 +46,8 @@ module Retriable
             @on_retry.call(exception, count) if @on_retry
             retry
           else
-            raise
+            raise unless exception.kind_of?(InvalidReturn)
+            result
           end
         else
           raise
@@ -73,6 +81,8 @@ module Retriable
       r.interval   = opts[:interval] if opts[:interval]
       r.timeout    = opts[:timeout] if opts[:timeout]
       r.on_retry   = opts[:on_retry] if opts[:on_retry]
+      r.on_return  = opts[:on_return] if opts[:on_return]
+      r.on << InvalidReturn if r.on_return 
     end.perform(&block)
   end
 end

--- a/test/retriable_test.rb
+++ b/test/retriable_test.rb
@@ -89,6 +89,23 @@ class RetriableTest < MiniTest::Unit::TestCase
     assert_equal 5, i
   end
 
+  def test_sleep_with_proc
+    sleep_values = []
+    Kernel.send(:define_method, :sleep) do |n|
+      sleep_values << n
+    end
+    
+    twice_attempts = Proc.new do |attempt|
+      2*attempt
+    end
+
+    retriable :interval => twice_attempts, :tries => 4 do 
+      raise StandardError
+    end
+  rescue StandardError
+    assert_equal [2,4,6], sleep_values
+  end
+
   def test_with_exception_regex
     begin
       i = 0

--- a/test/retriable_test.rb
+++ b/test/retriable_test.rb
@@ -45,6 +45,49 @@ class RetriableTest < MiniTest::Unit::TestCase
   rescue ArgumentError
     assert_equal 5, i
   end
+  
+  def test_with_on_return_and_criteria_was_met
+    i = 0
+    
+    tries_values = [1,2,3]
+    retry_if_less_than_three = Proc.new do |return_value, tries|
+      expected_param_value = tries_values.shift
+      assert_equal expected_param_value, tries
+      assert_equal return_value, tries
+
+      return_value < 3 
+    end
+    
+    return_values = [1,2,3,4,5]
+    retriable :on_return => retry_if_less_than_three, :tries => 5 do
+      i += 1
+      return_values.shift
+    end
+
+    assert_equal 3, i
+  end
+
+  def test_with_on_return_and_criteria_was_not_met
+    i = 0
+    
+    tries_values = [1,2,3,4,5]
+    retry_if_less_than_ten = Proc.new do |return_value, tries|
+      expected_param_value = tries_values.shift
+      assert_equal expected_param_value, tries
+      assert_equal return_value, tries
+
+      return_value < 10 
+    end
+    
+    return_values = [1,2,3,4,5]
+    result = retriable :on_return => retry_if_less_than_ten, :tries => 5 do
+      i += 1
+      return_values.shift
+    end
+
+    assert_equal 5, result
+    assert_equal 5, i
+  end
 
   def test_with_exception_regex
     begin


### PR DESCRIPTION
This pull request allows the return value of the code block to be inspected to determine if it should be re-executed. A new option :on_return is implemented, which accepts a Proc. If the Proc returns true, the block is re-executed.

Also added the ability to pass a Proc to the :interval option. The Proc accepts the retry attempt number as a paramater and returns the number of seconds to sleep.
